### PR TITLE
Bump build to rebuild with new stdlib

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   # PR made: https://github.com/Esri/lerc/pull/128
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # No real information, keep conda-forge defaults
     - {{ pin_subpackage('lerc', max_pin='x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This wasn't rebuilt after https://github.com/conda-forge/lerc-feedstock/commit/19674c72b281187690591584f5ad6db5cfdcecd5 so there's no build out without the libstdcxx dependency